### PR TITLE
Added better response upon Test Fails

### DIFF
--- a/ZhakalaneDk.Web/ZhakalenDk.Web.SGAI.Tests/AuthenticationTests.cs
+++ b/ZhakalaneDk.Web/ZhakalenDk.Web.SGAI.Tests/AuthenticationTests.cs
@@ -10,7 +10,8 @@ namespace ZhakalenDk.Web.SGAI.Tests.Auth
     public class AuthenticationTests
     {
         Authenticator auth = new Authenticator("credentials.json", "Unit Test Application");
-        string tokenPath = "Tokens";
+        string tokenFolder = "Tokens";
+        string tokenName = "Google.Apis.Auth.OAuth2.Responses.TokenResponse-user";
 
         [TestMethod]
         public void AuthAndStore ()
@@ -20,21 +21,21 @@ namespace ZhakalenDk.Web.SGAI.Tests.Auth
                 Assert.Fail("Authenticator was null");
             }
 
-            Assert.IsTrue(auth.AuthAndStoreToken(tokenPath));
+            Assert.IsTrue(auth.AuthAndStoreToken(tokenFolder), $"Used [{auth.SecretFileName}] and tried to store Token in folder [{tokenFolder}]");
         }
 
         [TestMethod]
         public void DeleteResponseTokens ()
         {
-            if ( auth == null || !auth.AuthAndStoreToken(tokenPath) )
+            string fullPath = $"{ Assembly.GetExecutingAssembly().Location }/{ tokenFolder}";
+            if ( auth == null || !auth.AuthAndStoreToken(tokenFolder) )
             {
                 Assert.Fail("Authenticator was null");
             }
 
             auth.EraseTokens();
 
-            Assert.IsFalse(File.Exists($"{Assembly.GetExecutingAssembly().Location}/{tokenPath}/Google.Apis.Auth.OAuth2.Responses.TokenResponse-user"));
-
+            Assert.IsFalse(File.Exists($"{fullPath}/{tokenName}"), $"File didn't exist at [{fullPath}]");
         }
 
     }

--- a/ZhakalaneDk.Web/ZhakalenDk.Web.SGAI/Authentication/Authenticator.cs
+++ b/ZhakalaneDk.Web/ZhakalenDk.Web.SGAI/Authentication/Authenticator.cs
@@ -47,7 +47,7 @@ namespace ZhakalenDk.Web.SGAI.Authentication
         /// <summary>
         /// The path to where the Google Response token was stored
         /// </summary>
-        public string TokenPath { get; private set; }
+        public string TokenFolder { get; private set; }
 
         protected bool InitiateService ()
         {
@@ -87,17 +87,17 @@ namespace ZhakalenDk.Web.SGAI.Authentication
                     new FileDataStore(_storeAt, true)).Result;
             }
 
-            TokenPath = _storeAt;
+            TokenFolder = _storeAt;
 
             return InitiateService();
         }
 
         /// <summary>
-        /// Clears the subfolder specified by the <see cref="TokenPath"/> where the Google Response Token was stored
+        /// Clears the subfolder specified by the <see cref="TokenFolder"/> where the Google Response Token was stored
         /// </summary>
         public void EraseTokens ()
         {
-            new FileDataStore(TokenPath, true).ClearAsync();
+            new FileDataStore(TokenFolder, true).ClearAsync();
         }
 
         /// <summary>


### PR DESCRIPTION
Authentication tests should now display a message that tell some information about the test upon an unseccessful test.

I also changed the Authenticator.TokenPath to .TokenFolder as the name ebtter represents the purpose of the property.